### PR TITLE
Redo swerve heading controller

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -22,13 +22,16 @@ kDirectionSlewRate = 1.2 * kMaxTurnSpeed # rad/s
 kSpeedSlewRate = 1.8 * kMaxSpeed # m/s
 kRotationSlewRate = 2.0 * kMaxTurnSpeed # m/s
 
-# Heading controller PID constants
-kHeadingTeleopP = 1 / wpimath.units.degreesToRadians(15)
-kHeadingTeleopI = 0
-kHeadingTeleopD = 0
-kHeadingAutoP = 1 / wpimath.units.degreesToRadians(5)
-kHeadingAutoI = 0
-kHeadingAutoD = 0
+kHeadingControllerP = 1 / wpimath.units.degreesToRadians(15)
+kHeadingControllerI = 0
+kHeadingControllerD = 0
+
+kChoreoTranslationP = 1 / wpimath.units.inchesToMeters(20)
+kChoreoTranslationI = 0
+kChoreoTranslationD = 0
+kChoreoRotationP = 1 / wpimath.units.degreesToRadians(5)
+kChoreoRotationI = 0
+kChoreoRotationD = 0
 
 # Elevator
 kMaxElevatorSpeed = wpimath.units.inchesToMeters(9) # m/s

--- a/constants.py
+++ b/constants.py
@@ -22,6 +22,14 @@ kDirectionSlewRate = 1.2 * kMaxTurnSpeed # rad/s
 kSpeedSlewRate = 1.8 * kMaxSpeed # m/s
 kRotationSlewRate = 2.0 * kMaxTurnSpeed # m/s
 
+# Heading controller PID constants
+kHeadingTeleopP = 1 / wpimath.units.degreesToRadians(15)
+kHeadingTeleopI = 0
+kHeadingTeleopD = 0
+kHeadingAutoP = 1 / wpimath.units.degreesToRadians(5)
+kHeadingAutoI = 0
+kHeadingAutoD = 0
+
 # Elevator
 kMaxElevatorSpeed = wpimath.units.inchesToMeters(9) # m/s
 kMinElevatorHeight = wpimath.units.inchesToMeters(0.1) # m

--- a/robot.py
+++ b/robot.py
@@ -128,7 +128,7 @@ class MyRobot(wpilib.TimedRobot):
 
 
     def autonomousInit(self) -> None:
-        self.drivetrain.set_heading_controller_mode(SwerveHeadingMode.FORCE_HEADING)
+        self.drivetrain.set_heading_controller_to_autonomous()
 
         self.trajectory = self.trajectoryChooser.getSelected()
         if self.trajectory:
@@ -173,7 +173,7 @@ class MyRobot(wpilib.TimedRobot):
 
 
     def teleopInit(self) -> None:
-        self.drivetrain.set_heading_controller_mode(SwerveHeadingMode.HUMAN_DRIVERS)
+        self.drivetrain.set_heading_controller_to_teleop()
 
 
     def teleopPeriodic(self) -> None:

--- a/robot.py
+++ b/robot.py
@@ -22,6 +22,7 @@ from sim.simswerve import SwerveDriveSim
 from subsystems.drivetrain import Drivetrain
 from subsystems.elevatorandarm import ElevatorAndArm
 from subsystems.hanger import Hanger
+from swerveheading import SwerveHeadingMode
 
 # from urcl import URCL
 
@@ -127,6 +128,8 @@ class MyRobot(wpilib.TimedRobot):
 
 
     def autonomousInit(self) -> None:
+        self.drivetrain.set_heading_controller_mode(SwerveHeadingMode.FORCE_HEADING)
+
         self.trajectory = self.trajectoryChooser.getSelected()
         if self.trajectory:
             initial_pose = self.trajectory.get_initial_pose(utils.isRedAlliance())
@@ -167,6 +170,10 @@ class MyRobot(wpilib.TimedRobot):
                 self.drivetrain.drive(0, 0, 0)
         
         self.previousAutoTime = currentAutoTime
+
+
+    def teleopInit(self) -> None:
+        self.drivetrain.set_heading_controller_mode(SwerveHeadingMode.HUMAN_DRIVERS)
 
 
     def teleopPeriodic(self) -> None:

--- a/swerveheading.py
+++ b/swerveheading.py
@@ -25,12 +25,6 @@ class SwerveHeadingMode(Enum):
     the robot to physically rotate in an unexpected way.
     """
 
-    FORCE_HEADING = 2
-    """
-    The heading controller will always attempt to steer the bot toward a
-    particular heading, regardless of human control or other factors.
-    """
-
 
 class SwerveHeadingController:
     def __init__(self, getHeading: Callable[[], Rotation2d], getRate: Callable[[], float], mode: SwerveHeadingMode) -> None:
@@ -38,7 +32,11 @@ class SwerveHeadingController:
         self.getRate = getRate
         self.mode: SwerveHeadingMode = mode
         self.goal: Rotation2d = self.getHeading()
-        self.PID = wpimath.controller.PIDController(constants.kHeadingTeleopP, constants.kHeadingTeleopI, constants.kHeadingTeleopD)
+        self.PID = wpimath.controller.PIDController(
+            constants.kHeadingControllerP,
+            constants.kHeadingControllerI,
+            constants.kHeadingControllerD,
+        )
         self.PID.enableContinuousInput(-math.pi, math.pi)
 
         self.stateTopic = ntutil.getStringTopic("/SwerveHeading/State")
@@ -77,8 +75,6 @@ class SwerveHeadingController:
                 # Use `rot`, and update the goal to the current gyro angle to maintain later.
                 self.goal = self.getHeading()
                 output = rot
-        elif self.mode == SwerveHeadingMode.FORCE_HEADING:
-            output = self.PID.calculate(self.getHeading().radians())
         else:
             ntutil.logAlert(self.badModeAlert, self.mode)
             output = rot
@@ -91,6 +87,3 @@ class SwerveHeadingController:
 
     def setMode(self, state: SwerveHeadingMode):
         self.mode = state
-
-    def setPID(self, kP: float, kI: float, kD: float):
-        self.PID.setPID(kP, kI, kD)

--- a/swerveheading.py
+++ b/swerveheading.py
@@ -1,55 +1,106 @@
-from enum import Enum
 import math
+from enum import Enum
+
 import navx
+import wpilib
 import wpimath.controller
 from wpimath.geometry import Rotation2d
+import wpimath.units
+
 import ntutil
 
-class SwerveHeadingState(Enum):
-    OFF = 0
-    MAINTAIN = 1
-    DISABLE = 2
+
+class SwerveHeadingMode(Enum):
+    DISABLED = 0
+    """
+    Entirely shut off the heading controller. Rotation speed will be passed
+    through unmodified.
+    """
+
+    HUMAN_DRIVERS = 1
+    """
+    The heading controller will try to maintain the current heading, but will
+    temporarily turn off if the drivers steer the robot, or if something causes
+    the robot to physically rotate in an unexpected way.
+    """
+
+    FORCE_HEADING = 2
+    """
+    The heading controller will always attempt to steer the bot toward a
+    particular heading, regardless of human control or other factors.
+    """
+
 
 class SwerveHeadingController:
-    state: SwerveHeadingState
-    goal: Rotation2d
-
-    def __init__(self, gyro: navx.AHRS) -> None:
-        self.gyro = gyro
-        self.state = SwerveHeadingState.OFF
-        self.shouldMaintain = False
-        self.goal = self.gyro.getRotation2d()
-        self.PID = wpimath.controller.PIDController(1 / math.radians(15), 0, 0)
+    def __init__(self, gyro: navx.AHRS, mode: SwerveHeadingMode) -> None:
+        self.gyro: navx.AHRS = gyro
+        self.mode: SwerveHeadingMode = mode
+        self.goal: Rotation2d = self.gyro.getRotation2d()
+        self.PID = wpimath.controller.PIDController(1 / wpimath.units.degreesToRadians(15), 0, 0)
         self.PID.enableContinuousInput(-math.pi, math.pi)
 
-        self.turningTopic = ntutil.getBooleanTopic("/isTurning")
-        self.translatingTOpic = ntutil.getBooleanTopic("/isTranslating")
+        self.stateTopic = ntutil.getStringTopic("/SwerveHeading/State")
+        self.goalTopic = ntutil.getStructTopic("/SwerveHeading/Goal", Rotation2d)
+        self.turningTopic = ntutil.getBooleanTopic("/SwerveHeading/IsTurning")
+        self.translatingTopic = ntutil.getBooleanTopic("/SwerveHeading/IsTranslating")
+        self.maintainingTopic = ntutil.getBooleanTopic("/SwerveHeading/IsMaintaining")
+        self.gyroRateTopic = ntutil.getFloatTopic("/SwerveHeading/GyroRate")
+        self.outputTopic = ntutil.getFloatTopic("/SwerveHeading/Output")
 
-    def update(self, xSpeed: float, ySpeed: float, rot: float) -> float:
-        if self.state == SwerveHeadingState.DISABLE:
-            return rot
-        
-        bot_turning = math.fabs(rot) > 0.1 or math.fabs(self.gyro.getRate()) > 1
-        bot_translating = xSpeed != 0 or ySpeed != 0
-        shouldChangeToMaintain = not bot_turning and bot_translating
+        self.badModeAlert = wpilib.Alert("Bad mode for swerve heading controller", wpilib.Alert.AlertType.kError)
 
-        self.turningTopic.set(bot_turning)
-        self.translatingTOpic.set(bot_translating)
+    def update(self, speed: float, rot: float) -> float:
+        self.stateTopic.set(str(self.mode))
+        self.goalTopic.set(self.goal)
+        self.gyroRateTopic.set(self.getRateRadiansPerSecond())
 
-        if shouldChangeToMaintain:
-            self.state = SwerveHeadingState.MAINTAIN
-            self.PID.setSetpoint(self.goal.radians())
+        self.PID.setSetpoint(self.goal.radians())
+
+        if self.mode == SwerveHeadingMode.DISABLED:
+            output = rot
+        elif self.mode == SwerveHeadingMode.HUMAN_DRIVERS:
+            # TODO: Validate if 15 deg/s is a reasonable threshold for disabling the controller.
+            bot_turning = abs(rot) > 0.1 or abs(self.getRateRadiansPerSecond()) > wpimath.units.degreesToRadians(15)
+            bot_translating = speed > 0
+            should_maintain_heading = not bot_turning and bot_translating
+
+            self.turningTopic.set(bot_turning)
+            self.translatingTopic.set(bot_translating)
+            self.maintainingTopic.set(should_maintain_heading)
+
+            if should_maintain_heading:
+                # Run PID with the previously-set goal, ignoring `rot`
+                output = self.PID.calculate(self.gyro.getRotation2d().radians())
+            else:
+                # Use `rot`, and update the goal to the current gyro angle to maintain later.
+                self.goal = self.gyro.getRotation2d()
+                output = rot
+        elif self.mode == SwerveHeadingMode.FORCE_HEADING:
+            output = self.PID.calculate(self.gyro.getRotation2d().radians())
         else:
-            self.state = SwerveHeadingState.OFF
-            self.goal = self.gyro.getRotation2d()
-        
-        if self.state == SwerveHeadingState.OFF:
-            return rot
-        else:
-            return self.PID.calculate(self.gyro.getRotation2d().radians())
-        
-    def setGoal(self, goal: Rotation2d): # because navX is clockwise positive, we have to negate it
+            ntutil.logAlert(self.badModeAlert, self.mode)
+            output = rot
+
+        self.outputTopic.set(output)
+        return output
+
+    def getRateRadiansPerSecond(self) -> float:
+        """
+        The NavX reports its rate in degrees/second instead of radians/second.
+        Please use this method instead of `self.gyro.getRate()` for our own
+        sanity.
+
+        Also, be aware that `getRate()` has a history of being totally broken:
+        https://github.com/kauailabs/navxmxp/issues/69
+
+        But this was probably fixed (probably!) for the 2025 season:
+        https://github.com/Studica-Robotics/NavX/issues/5
+        https://github.com/Studica-Robotics/NavX/issues/6
+        """
+        return wpimath.units.degreesToRadians(self.gyro.getRate())
+
+    def setGoal(self, goal: Rotation2d):
         self.goal = goal
 
-    def setState(self, state: SwerveHeadingState):
-        self.state = state
+    def setMode(self, state: SwerveHeadingMode):
+        self.mode = state


### PR DESCRIPTION
The swerve heading controller had a few issues:

- The use of a "state" variable was mostly superfluous, since it would change state on every update. In other words, there was no need for the `OFF` and `MAINTAIN` states, only `DISABLED`.
- The use of `getRate()` meant that the heading controller would temporarily disable and update its goal heading if the robot's angular velocity ever exceeded one degree per second - which means it did next to nothing. (This may have worked before due to a bug in `getRate` that caused it to report something like radians per second instead.)

I've reworked it in a way I think is clearer. I also added a `FORCE_HEADING` mode that we can use in auto to forcibly maintain a specific heading, regardless of other conditions. I think this may also be useful for teleop assist features, if we get to them, such as pointing at specific targets on the reef.