### PR TITLE
Use odometry for heading

### DIFF
--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -172,10 +172,18 @@ class Drivetrain:
         return self.odometry.getPose()
 
     def get_heading(self) -> Rotation2d:
-        return self.gyro.getRotation2d()
+        return self.odometry.getPose().rotation()
 
     def drive(self, xSpeed: float, ySpeed: float, turnSpeed: float, angle: Rotation2d | None = None):
-        newSpeeds = ChassisSpeeds2175.fromFieldRelativeSpeeds(xSpeed, ySpeed, turnSpeed, self.gyro.getRotation2d())
+        """
+        Drives the robot in the given direction IN FIELD COORDINATES. Note that because we use the
+        "always blue origin" convention, as described in the WPILib docs, this means that
+        speeds must be flipped when humans are driving on the red alliance side of the field.
+
+        https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#always-blue-origin
+        """
+
+        newSpeeds = ChassisSpeeds2175.fromFieldRelativeSpeeds(xSpeed, ySpeed, turnSpeed, self.get_heading())
 
         # If stopping the robot, preserve the old direction instead of going to
         # angle 0. The speeds will indeed be exactly equal to zero in teleop
@@ -203,6 +211,6 @@ class Drivetrain:
             sample.vy + self.y_controller.calculate(pose.Y(), sample.y),
             sample.omega, # TODO: Add heading controller - see Getting Started docs for Choreo
         )
-        
-    def reset_heading(self):
-        self.gyro.reset()
+
+    def reset_heading(self, angle: float):
+        self.odometry.resetRotation(Rotation2d(angle))

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 import math
 
+import wpilib
+
 
 def lerp(a: float, b: float, t: float) -> float:
     return (1-t) * a + t * b
@@ -72,3 +74,12 @@ class RotationSlewRateLimiter:
 
     def setRateLimit(self, rateLimit: float): # rad/s
         self.rateLimit = rateLimit
+
+def isRedAlliance():
+    return wpilib.DriverStation.getAlliance() == wpilib.DriverStation.Alliance.kRed
+
+def driverForwardAngle() -> float:
+    if isRedAlliance():
+        return math.pi
+    else:
+        return 0


### PR DESCRIPTION
This ensures that field-relative drive takes the odometry pose into account - which is critical for Choreo paths.

The main snag with this is that we now must always work in field coordinates, and zero on the gyro no longer means "away from the driver" - it depends what alliance you're on! This means that teleop controls need to be adjusted - both the normal left-stick controls and the angle reset need to be adapted to this new system.